### PR TITLE
Fix code scanning alert no. 41: Deserialization of user-controlled data

### DIFF
--- a/examples/YOLO_server_api/model_files.py
+++ b/examples/YOLO_server_api/model_files.py
@@ -20,7 +20,8 @@ async def update_model_file(model: str, model_file: Path) -> None:
         raise ValueError(f"Invalid file: {model_file}. Must be a valid `.pt` file.")
 
     try:
-        torch.load(model_file)
+        # Validate the model file by loading it with torch.jit.load
+        torch.jit.load(model_file)
     except Exception as e:
         raise ValueError(f"Invalid PyTorch model file: {e}")
 


### PR DESCRIPTION
Fixes [https://github.com/yihong1120/Construction-Hazard-Detection/security/code-scanning/41](https://github.com/yihong1120/Construction-Hazard-Detection/security/code-scanning/41)

To fix the problem, we should avoid using `torch.load` directly on user-controlled input. Instead, we can use a safer method to validate the content of the file before loading it. One approach is to use `torch.jit.load`, which is designed for loading TorchScript models and is generally safer. Additionally, we can further validate the file content to ensure it is a valid PyTorch model.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
